### PR TITLE
Require canonical, minimum-length encoding of height.

### DIFF
--- a/bip-0034.md
+++ b/bip-0034.md
@@ -21,7 +21,7 @@ Bitcoin blocks and transactions are versioned binary structures. Both currently 
 ==Specification==
 
 # Treat transactions with a version greater than 1 as non-standard (official Satoshi client will not mine or relay them).
-# Add height as the first item in the coinbase transaction's scriptSig, and increase block version to 2. The format of the height is "serialized CScript" -- first byte is number of bytes in the number (will be 0x03 on main net for the next 300 or so years), following bytes are little-endian representation of the number.  Height is the height of the mined block in the block chain, where the genesis block is height zero (0).
+# Add height as the first item in the coinbase transaction's scriptSig, and increase block version to 2. The format of the height must be "canonical, minimum-length, serialized CScript" -- first byte is number of bytes in the number (0x03 on main net for the next 300 or so years), following bytes are little-endian representation of the number.  Height is the height of the mined block in the block chain, where the genesis block is height zero (0).
 # 75% rule: If 750 of the last 1,000 blocks are version 2 or greater, reject invalid version 2 blocks. (testnet3: 51 of last 100)
 # 95% rule ("Point of no return"): If 950 of the last 1,000 blocks are version 2 or greater, reject all version 1 blocks. (testnet3: 75 of last 100)
 


### PR DESCRIPTION
As discussed in pull request https://github.com/bitcoin/bitcoin/pull/1764 -- consensus is that the block height encoding should be strictly specified, on the general principle that allowing non-canonical encodings are more likely to open up security holes or trigger implementation-specific bugs.
